### PR TITLE
DependencyConfigurationHelper: Delegated dependency resolution

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -80,6 +80,7 @@ dependencies {
     implementation 'me.tatarka.retrolambda.projectlombok:lombok.ast:0.2.3.a2'
     implementation 'me.tatarka:gradle-retrolambda:3.2.5'
     implementation 'org.yaml:snakeyaml:1.23'
+    testAnnotationProcessor 'com.github.stephanenicolas.toothpick:toothpick-compiler:1.1.3'
     testImplementation 'com.github.stephanenicolas.toothpick:toothpick-testing:1.1.3'
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-core:2.22.0'

--- a/app/src/main/java/ch/epfl/sweng/erpa/activities/DependencyConfigurationAgnosticActivity.java
+++ b/app/src/main/java/ch/epfl/sweng/erpa/activities/DependencyConfigurationAgnosticActivity.java
@@ -1,51 +1,37 @@
 package ch.epfl.sweng.erpa.activities;
 
 import android.app.Activity;
-import android.app.Application;
 import android.content.Intent;
 import android.os.Bundle;
 
 import com.annimon.stream.Collectors;
 import com.annimon.stream.Stream;
 
-import java.lang.reflect.Field;
 import java.util.List;
-import java.util.Set;
 
 import javax.inject.Inject;
-import javax.inject.Named;
 
+import ch.epfl.sweng.erpa.operations.DependencyConfigurationHelper;
 import ch.epfl.sweng.erpa.operations.DependencyConfigurator;
-import toothpick.Scope;
 import toothpick.Toothpick;
 
 public abstract class DependencyConfigurationAgnosticActivity extends Activity {
-    @Inject @Named("Dependency Configurators") Set<DependencyConfigurator> coordinators;
-
-    private Scope scope;
+    @Inject DependencyConfigurationHelper dependencyConfigurationHelper;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        Application application = getApplication();
-        scope = Toothpick.openScopes(application, this);
-        Toothpick.inject(this, scope);
+        Toothpick.inject(this, Toothpick.openScopes(getApplication(), this));
 
-        Set<Class> autowiredClasses = Stream.of(this.getClass().getFields())
-                // Injected fields
-                .filter(f -> f.isAnnotationPresent(Inject.class))
-                // Field class
-                .map(Field::getType)
-                .collect(Collectors.toSet());
+        List<Class> unconfiguredDependencies =
+                dependencyConfigurationHelper.getNotConfiguredDependenciesForInstance(this);
 
-        Set<DependencyConfigurator> coordinatorsWithUnconfiguredDependencies = Stream.of(coordinators)
-                .filter(cc -> autowiredClasses.contains(cc.configuredDependencyClass()))
-                // Only coordinators with non-configured dependencies
-                .filter(cc -> !cc.dependencyIsConfigured())
-                .collect(Collectors.toSet());
-
-        if (!coordinatorsWithUnconfiguredDependencies.isEmpty()) {
-            List<Intent> configurationActivities = Stream.of(coordinatorsWithUnconfiguredDependencies)
+        if (!unconfiguredDependencies.isEmpty()) {
+            List<Intent> configurationActivities = Stream.of(unconfiguredDependencies)
+                    .map(depCls -> dependencyConfigurationHelper
+                            .getDependencyConfiguratorForClass(depCls)
+                            .orElseThrow(() -> new IllegalArgumentException(
+                                    "Cannot find Configurator for class " + depCls.getName())))
                     .map(DependencyConfigurator::dependencyConfigurationIntent)
                     .map(i -> i.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_TASK_ON_HOME))
                     .collect(Collectors.toList());
@@ -66,6 +52,5 @@ public abstract class DependencyConfigurationAgnosticActivity extends Activity {
     @Override
     protected void onResume() {
         super.onResume();
-        Toothpick.inject(this, scope);
     }
 }

--- a/app/src/main/java/ch/epfl/sweng/erpa/operations/DependencyConfigurationHelper.java
+++ b/app/src/main/java/ch/epfl/sweng/erpa/operations/DependencyConfigurationHelper.java
@@ -1,0 +1,142 @@
+package ch.epfl.sweng.erpa.operations;
+
+import com.annimon.stream.Collectors;
+import com.annimon.stream.Exceptional;
+import com.annimon.stream.Optional;
+import com.annimon.stream.Stream;
+import com.annimon.stream.function.Function;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import javax.inject.Inject;
+import javax.inject.Named;
+import javax.inject.Singleton;
+
+import lombok.Data;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import toothpick.Scope;
+
+import static com.annimon.stream.function.Function.Util.safe;
+
+@Singleton
+public class DependencyConfigurationHelper {
+    @Inject @Named("Dependency Configurators") Set<DependencyConfigurator<?>> coordinators;
+    @Inject @Named("application") Scope scope;
+
+    @Inject public DependencyConfigurationHelper() {
+    }
+
+    /**
+     * Calculates a list of not configured dependencies required by the given instance.
+     * <p>
+     * This method also resolves nested dependencies.
+     *
+     * @param instance the object to scan for injected but not configured dependencies.
+     * @return A sorted list with required dependency classes in an optimal order to be resolved.
+     */
+    public List<Class> getNotConfiguredDependenciesForInstance(Object instance) {
+        List<Class> sortedNotConfiguredDependencies = Stream.of(makeInstanceDependencyTree(instance.getClass(), instance, new HashMap<>())
+                .map(DfsTreeSolver::topologicalSort)
+                .orElse(new ArrayList<>()))
+                .map(t -> t.getSupportingType())
+                .filterNot(instance.getClass()::equals)
+                .collect(Collectors.toList());
+        // DfsTreeSolver::topologicalSort returns a list sorted from the oldest parent
+        Collections.reverse(sortedNotConfiguredDependencies);
+        return sortedNotConfiguredDependencies;
+    }
+
+    public Optional<DependencyConfigurator<?>> getDependencyConfiguratorForClass(Class<?> cls) {
+        return Stream.of(coordinators)
+                .filter(coordinator -> coordinator.configuredDependencyClass().isAssignableFrom(cls))
+                .findFirst();
+    }
+
+    @SuppressWarnings("unchecked") // Horrible casts due to Java Generics partial support for type variance.
+    private <T> Optional<Tree<Class<T>>> makeInstanceDependencyTree(Class<? extends T> type, T rootInstance, Map<Class, Tree> treeCache ) {
+        if (treeCache.containsKey(type))
+            return Optional.of(Objects.requireNonNull(treeCache.get(type)));
+
+        Set<Class> instanceInjectedTypes = Stream.of(rootInstance.getClass().getFields())
+                .filter(f -> f.isAnnotationPresent(Inject.class))
+                .map(Field::getType)
+                .collect(Collectors.toSet());
+
+        // Claim responsibility for this tree
+        treeCache.put(type, new Tree<>(type, rootInstance.getClass()));
+
+        // If it's a terminal tree, just exit
+        if (instanceInjectedTypes.isEmpty())
+            return Optional.empty();
+
+        Set<Tree> instanceDependencies = Stream.of(coordinators)
+                .filter(cc -> instanceInjectedTypes.contains(cc.configuredDependencyClass()))
+                // Coordinators with non-configured dependencies
+                .filterNot(DependencyConfigurator::dependencyIsConfigured)
+                .map(DependencyConfigurator::configuredDependencyClass)
+                // Examine dependency
+                .map(embeddedDependencyClass -> {
+                    Object instance = scope.getInstance(embeddedDependencyClass);
+                    return ((Optional<Tree>) (Object) makeInstanceDependencyTree(embeddedDependencyClass, instance, treeCache))
+                            // The tree was nonetheless claimed, retrieve the terminal tree.
+                            .orElse(treeCache.get(embeddedDependencyClass));
+                })
+                .collect(Collectors.toSet());
+
+        Tree dependencyTree = treeCache.get(type);
+        // Integrate recursion results.
+        dependencyTree.setChildren(instanceDependencies);
+        return Optional.of(dependencyTree);
+    }
+}
+
+@Data
+@RequiredArgsConstructor
+class Tree<T> {
+    @NonNull Class supportingType;
+    @NonNull T value;
+    @NonNull Set<Tree> children;
+    Mark mark = Mark.NONE;
+    public Tree(T value) {
+        this(value.getClass(), value);
+    }
+    public Tree(Class supportingType, T value) {
+        this(supportingType, value, new HashSet<>());
+    }
+
+    enum Mark {NONE, TEMPORARY, PERMANENT}
+}
+
+class DfsTreeSolver {
+    /**
+     * Performs topological sort on a tree
+     *
+     * @param tree Tree to sort
+     * @param <T>  Type of the tree
+     * @return List of trees such that the first element is a parent of every other element
+     */
+    public static <T> List<Tree<T>> topologicalSort(Tree<T> tree) {
+        LinkedList<Tree<T>> sorted = new LinkedList<>();
+        visit(tree, sorted);
+        return sorted;
+    }
+
+    private static <T> void visit(Tree<T> node, LinkedList<Tree<T>> accumulator) {
+        if (node.mark == Tree.Mark.PERMANENT) return;
+        if (node.mark == Tree.Mark.TEMPORARY) throw new IllegalArgumentException("Cyclic tree");
+        node.mark = Tree.Mark.TEMPORARY;
+        Stream.of(node.children).forEach(child -> visit(child, accumulator));
+        node.mark = Tree.Mark.PERMANENT;
+        accumulator.addFirst(node);
+    }
+}

--- a/app/src/test/java/ch/epfl/sweng/erpa/operations/DependencyConfigurationHelperTest.java
+++ b/app/src/test/java/ch/epfl/sweng/erpa/operations/DependencyConfigurationHelperTest.java
@@ -1,0 +1,217 @@
+package ch.epfl.sweng.erpa.operations;
+
+import android.content.Intent;
+
+import com.annimon.stream.Collectors;
+import com.annimon.stream.Optional;
+import com.annimon.stream.Stream;
+import com.annimon.stream.function.Function;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Random;
+import java.util.Set;
+
+import javax.inject.Inject;
+
+import toothpick.Scope;
+import toothpick.Toothpick;
+import toothpick.config.Module;
+import toothpick.configuration.Configuration;
+import toothpick.testing.ToothPickRule;
+
+import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.assertTrue;
+
+@SuppressWarnings("unused") // Workaround over type erasure, fields are used later via Reflection.
+@RunWith(MockitoJUnitRunner.class)
+public class DependencyConfigurationHelperTest {
+    @Rule public final ToothPickRule toothPickRule = new ToothPickRule(this, "dchTest");
+
+    @Inject Scope scope;
+
+    @Before
+    public void prepare() {
+        Toothpick.setConfiguration(Configuration.forDevelopment().enableReflection());
+        scope = toothPickRule.getScope();
+        scope.installModules(new Module() {{
+            bind(Scope.class).withName("application").toInstance(scope);
+            bind(DependencyConfigurationHelper.class).to(DependencyConfigurationHelper.class);
+            bind(Set.class).withName("Dependency Configurators")
+                    .toInstance(new HashSet<DependencyConfigurator>());
+        }});
+    }
+
+    @Test
+    public void testFlatDependencyResolution() {
+        // @formatter:off
+        class D1 {} class D2 {} class D3 {} class D4 {} class D5 {}
+        // @formatter:on
+        DchTestHelper testHelper = new DchTestHelper(new D1(), new D2(), new D3(), new D4(), new D5()) {
+            @Inject public D1 f1;
+            @Inject public D2 f2;
+            @Inject public D3 f3;
+            @Inject public D4 f4;
+            @Inject public D5 f5;
+        };
+        DependencyConfigurationHelper underTest = scope.getInstance(DependencyConfigurationHelper.class);
+
+        // Assert all classes have been resolved
+        Set<Class> expectedDependencyClasses = testHelper.dependencyConfigurators.keySet();
+        assertEquals(expectedDependencyClasses,
+                new HashSet<>(underTest.getNotConfiguredDependenciesForInstance(testHelper)));
+
+        Stream.of(expectedDependencyClasses)
+                .forEach(cls -> {
+                    Optional<DependencyConfigurator<?>> dc = underTest.getDependencyConfiguratorForClass(cls);
+                    assertTrue(dc.isPresent());
+                    assertEquals(testHelper.dependencyConfigurators.get(cls), dc.get());
+                });
+    }
+
+    @Test
+    public void testRecursiveDependencyResolution() {
+        DependencyConfigurationHelper underTest = scope.getInstance(DependencyConfigurationHelper.class);
+
+        // The order in the constructor is important due to the way the DependencyConfigurationHelper initializes.
+        DchTestHelper testHelper = new DchTestHelper(new D4(), new D3(), new D2(), new D1()) {
+            @Inject public D1 f1;
+            @Inject public D2 f2;
+            @Inject public D3 f3;
+            @Inject public D4 f4;
+        };
+
+        //noinspection unchecked -- Raw Classes.
+        List<Class> expected = Stream.of(D1.class, D2.class, D3.class, D4.class).collect(Collectors.toList());
+        Collections.reverse(expected);
+        assertEquals(expected, underTest.getNotConfiguredDependenciesForInstance(testHelper));
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testDfsSolverTopologicalTreeSortExceptsOnCycle() {
+        Tree<Integer> t1 = new Tree<>(1);
+        Tree<Integer> t2 = new Tree<>(2);
+        t1.getChildren().add(t2);
+        t2.getChildren().add(t1);
+
+        DfsTreeSolver.topologicalSort(t1);
+    }
+
+    @Test
+    public void testDfsSolverTopologicalTreeSort() {
+        int maxTrees = 1000;
+        int nChilds = 300;
+
+        Map<Integer, Tree<Integer>> treesPool = new HashMap<>();
+
+        Tree<Integer> testTree = new Tree<>(Integer.class, 0, Stream.of(mkBoundedArray(0, maxTrees / 2, nChilds))
+                .map(i -> mkTreeFromSuites(i, mkBoundedArray(i + 1, maxTrees, nChilds), treesPool))
+                .collect(Collectors.toSet()));
+
+        List<Tree<Integer>> sortedTrees = Stream.of(DfsTreeSolver.topologicalSort(testTree))
+                .skip(1) // The first node it's always present
+                .collect(Collectors.toList());
+
+        // Verify that by removing the left-most node each time, we never leave orphan children
+        sortedTrees.forEach(tree -> {
+            treesPool.remove(tree.getValue());
+            Stream.of(tree.getChildren()).forEach(child -> assertTrue(treesPool.containsKey(child.getValue())));
+        });
+    }
+
+    private Set<Integer> mkBoundedArray(int min, int max, int count) {
+        return Stream.generate(() -> min + (int) (new Random().nextDouble() * (max - min))).limit(1000)
+                .distinct().limit(count).sorted().collect(Collectors.toSet());
+    }
+
+    private Tree<Integer> mkTreeFromSuites(int value, Set<Integer> children, Map<Integer, Tree<Integer>> pool) {
+        Stream.of(children).forEach(childValue -> {
+            Tree<Integer> node = pool.getOrDefault(value, new Tree<>(value));
+            Tree<Integer> child = pool.getOrDefault(childValue, new Tree<>(childValue));
+            Objects.requireNonNull(node).getChildren().add(child);
+            pool.put(childValue, child);
+            pool.put(value, node);
+        });
+        return pool.getOrDefault(value, new Tree<>(value));
+    }
+
+    class Pair {
+        public Pair(Object first, Object second) {
+            this.first = first;
+            this.second = second;
+        }
+
+        public Object first;
+        public Object second;
+    }
+
+    // @formatter:off
+    public static class D4 { @Inject public D4() {} }
+    public static class D3 { @Inject public D4 f; }
+    public static class D2 { @Inject public D3 f; }
+    public static class D1 { @Inject public D2 f; }
+    // @formatter:on
+
+    @SuppressWarnings("unchecked")
+    abstract class DchTestHelper {
+        Map<Class, DependencyConfigurator<?>> dependencyConfigurators;
+
+        DchTestHelper(Object... fieldValues) {
+            Map<Object, Class> objectClassMap = new HashMap<>();
+            // Set fields and associate dependencyConfigurators
+            dependencyConfigurators = Stream.of(this.getClass().getFields())
+                    .map(f -> Stream.of(fieldValues)
+                            .filter(fv -> f.getType().isAssignableFrom(fv.getClass()))
+                            .findFirst()
+                            .map(Function.Util.safe((fv -> {
+                                f.set(this, fv);
+                                objectClassMap.put(fv, f.getType());
+                                return f.getType();
+                            })))
+                            .orElse(null))
+                    .collect(Collectors.toMap(ft -> ft, this::mkDependencyConfigurator));
+            DchTestHelper dchTestHelper = this;
+
+            scope.installModules(new Module() {{
+                bind(DchTestHelper.class).toInstance(dchTestHelper);
+            }});
+
+            Toothpick.inject(this, scope);
+
+            Stream.of(fieldValues).map(v -> new Pair(v, objectClassMap.get(v))).forEach(ocPair -> {
+                Toothpick.inject(ocPair.first, scope);
+                scope.installModules(new Module() {{
+                    bind((Class)ocPair.second).toInstance(ocPair.first);
+                }});
+            });
+
+            scope.getInstance(Set.class, "Dependency Configurators").addAll(dependencyConfigurators.values());
+        }
+
+        private DependencyConfigurator<?> mkDependencyConfigurator(Class<?> forClass) {
+            return new DependencyConfigurator<Object>() {
+                @Override public boolean dependencyIsConfigured() {
+                    return false;
+                }
+
+                @Override public Intent dependencyConfigurationIntent() {
+                    return null;
+                }
+
+                @Override public Class<Object> configuredDependencyClass() {
+                    return (Class<Object>) forClass;
+                }
+            };
+        }
+    }
+}


### PR DESCRIPTION
DependencyConfigurationHelper implements a recursive DFS for topological sorting.
The returned dependencies are sorted by resolution order.

Signed-off-by: Roosembert Palacios <roosembert.palacios@epfl.ch>